### PR TITLE
fix: make app and worker shutdown gracefully

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -43,7 +43,7 @@ func NewController(
 }
 
 func (c *Controller) AppHealth(ctx echo.Context) error {
-	return ctx.JSON(http.StatusOK, []byte("app is healthy and running"))
+	return ctx.JSON(http.StatusOK, "app is healthy and running")
 }
 
 func (c *Controller) InternalError(ctx echo.Context) error {

--- a/routes/api.go
+++ b/routes/api.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"time"
+
 	"github.com/MBvisti/grafto/controllers"
 	"github.com/MBvisti/grafto/server/middleware"
 	"github.com/labstack/echo/v4"
@@ -8,6 +10,7 @@ import (
 
 func apiRoutes(router *echo.Group, controllers controllers.Controller, middleware middleware.Middleware) {
 	router.GET("/health", func(c echo.Context) error {
+		time.Sleep(6 * time.Second)
 		return controllers.AppHealth(c)
 	})
 


### PR DESCRIPTION
# What

Ensures that both app and worker shuts down gracefully. Closes #62 